### PR TITLE
Refactor: Enhance create-plotly-chart

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -158,7 +158,11 @@ export async function POST(request: Request) {
         const result = streamText({
           model: myProvider.languageModel(selectedChatModel),
           system: systemPrompt({ selectedChatModel, requestHints }),
-          messages,
+          messages, // This is the array of CoreMessage objects
+          context: { // Add this context object
+            chatId: id, // 'id' is the variable holding the chat ID in this route
+            messages: messages // Pass the messages array into the context as well
+          },
           maxSteps: 5,
           experimental_activeTools:
             selectedChatModel === 'chat-model-reasoning'

--- a/components/visualizations/PlotlyChart.tsx
+++ b/components/visualizations/PlotlyChart.tsx
@@ -18,9 +18,10 @@ export interface FigureJSON {
 interface PlotlyChartProps {
   figure: FigureJSON;
   title?: string;
+  visualizationId?: string; // Add this line
 }
 
-export function PlotlyChart({ figure, title }: PlotlyChartProps) {
+export function PlotlyChart({ figure, title, visualizationId }: PlotlyChartProps) {
   const ref = useRef<any>(null);
 
   // Ensure responsiveness

--- a/lib/ai/tools/create-plotly-chart.ts
+++ b/lib/ai/tools/create-plotly-chart.ts
@@ -1,5 +1,11 @@
 import { tool } from 'ai';
 import { z } from 'zod';
+import { myProvider } from '@/lib/ai/providers';
+import { db } from '@/lib/db';
+import { visualizations } from '@/lib/db/schema';
+import type { CoreMessage } from 'ai';
+import { auth } from '@/app/(auth)/auth';
+import { generateText } from 'ai';
 
 export const createPlotlyChart = tool({
   description:
@@ -8,8 +14,54 @@ export const createPlotlyChart = tool({
     figure: z.any().describe('Plotly figure JSON'),
     title: z.string().optional().describe('Optional title'),
   }),
-  // For streamText usage, we simply return the payload; client renders via tool invocation
-  execute: async (args) => {
-    return args as any;
+  execute: async (
+    args: { figure: any; title?: string },
+    context: { chatId: string; messages: CoreMessage[] },
+  ) => {
+    try {
+      const session = await auth();
+      if (!session?.user?.id) {
+        throw new Error('User not authenticated');
+      }
+
+      const summaryPrompt = context.messages
+        .map((m) => `${m.role}: ${m.content}`)
+        .join('\n');
+
+      const { text: summary } = await generateText({
+        model: myProvider.languageModel('artifact-model'),
+        prompt: summaryPrompt,
+        system:
+          'Summarize the following conversation in one sentence. This summary will be used as a description for a generated chart. The user has just asked to create this chart.',
+      });
+
+      const newVisualization = await db
+        .insert(visualizations)
+        .values({
+          userId: session.user.id,
+          chatId: context.chatId,
+          type: 'plot',
+          title: args.title || 'Untitled Chart',
+          description: summary,
+          data: { figure: args.figure },
+        })
+        .returning({ insertedId: visualizations.id });
+
+      if (!newVisualization || newVisualization.length === 0 || !newVisualization[0].insertedId) {
+        throw new Error('Failed to save visualization to database');
+      }
+
+      return {
+        figure: args.figure,
+        title: args.title,
+        visualizationId: newVisualization[0].insertedId,
+      };
+    } catch (error) {
+      console.error('Error creating Plotly chart:', error);
+      // Re-throw the error or return an error structure as appropriate
+      // For now, let's re-throw, but you might want to return a structured error
+      // that the AI can understand and potentially relay to the user.
+      throw error;
+    }
   },
 }); 

--- a/lib/ai/tools/plotly.tsx
+++ b/lib/ai/tools/plotly.tsx
@@ -16,9 +16,17 @@ export const createPlotlyChart = {
     title: z.string().optional().describe('Optional title to render above the chart'),
   }),
   // Generator so we can show a loading placeholder while the bundle loads on the client
-  generate: async function* ({ figure, title }: { figure: any; title?: string }) {
+  generate: async function* ({
+    figure,
+    title,
+    visualizationId,
+  }: {
+    figure: any;
+    title?: string;
+    visualizationId: string;
+  }) {
     yield <Spinner />;
-    return <PlotlyChart figure={figure} title={title} />;
+    return <PlotlyChart figure={figure} title={title} visualizationId={visualizationId} />;
   },
 };
 


### PR DESCRIPTION
This commit refactors the `create-plotly-chart` functionality to:

1.  Generate a contextual summary of our conversation that led to the chart creation. This summary is used as the chart's description.
2.  Save the chart's metadata (title, description, data, your ID, chat ID) to the `visualizations` database table.
3.  Pass the new `visualizationId` to the PlotlyChart component.

Changes include:
- Modified `lib/ai/tools/create-plotly-chart.ts` to include the server-side logic for summary generation (using OpenAI) and database insertion. The `execute` function now returns `visualizationId`.
- Updated `lib/ai/tools/plotly.tsx` (client-side rendering wrapper) to accept `visualizationId` from the server and pass it to the `PlotlyChart` component.
- Modified `components/visualizations/PlotlyChart.tsx` to accept `visualizationId` as a prop.
- Updated `app/(chat)/api/chat/route.ts` to inject `chatId` and `messages` into the execution context when calling `streamText`, making them available to the `createPlotlyChart` functionality.