### PR TITLE
It sounds like you're describing an update to how molecule structures…

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -159,7 +159,7 @@ export async function POST(request: Request) {
           model: myProvider.languageModel(selectedChatModel),
           system: systemPrompt({ selectedChatModel, requestHints }),
           messages, // This is the array of CoreMessage objects
-          context: { // Add this context object
+          context: {
             chatId: id, // 'id' is the variable holding the chat ID in this route
             messages: messages // Pass the messages array into the context as well
           },

--- a/lib/ai/tools/show-molecule-structure.ts
+++ b/lib/ai/tools/show-molecule-structure.ts
@@ -1,5 +1,11 @@
 import { tool } from 'ai';
 import { z } from 'zod';
+import { myProvider } from '@/lib/ai/providers';
+import { db } from '@/lib/db';
+import { visualizations } from '@/lib/db/schema';
+import type { CoreMessage } from 'ai';
+import { auth } from '@/app/(auth)/auth';
+import { generateText } from 'ai';
 
 /**
  * Tool: showMoleculeStructure
@@ -24,13 +30,54 @@ export const showMoleculeStructure = tool({
       .optional()
       .describe('Optional short title to render above the viewer.'),
   }),
-  execute: async (args) => {
-    // Return an object compatible with the molecule3dArtifact
-    return {
-      type: 'molecule3d',
-      identifierType: 'pdb',
-      identifier: args.pdbId,
-      title: args.title || `Molecule: ${args.pdbId.toUpperCase()}`,
-    };
+  execute: async (args, context: { chatId: string; messages: CoreMessage[] }) => {
+    try {
+      const session = await auth();
+      if (!session?.user?.id) {
+        throw new Error('User not authenticated');
+      }
+
+      const summaryPrompt = context.messages
+        .map((message) => `${message.role}: ${message.content}`)
+        .join('\n');
+      const { text: summary } = await generateText({
+        model: myProvider.languageModel('artifact-model'),
+        prompt: summaryPrompt,
+        system:
+          'Summarize the following conversation in one sentence. This summary will be used as a description for a generated molecule visualization. The user has just asked to view this molecule. Conversation:\n\n' +
+          JSON.stringify(context.messages),
+      });
+
+      const newVisualization = await db
+        .insert(visualizations)
+        .values({
+          userId: session.user.id,
+          chatId: context.chatId,
+          type: 'molecule',
+          title: args.title || `Molecule: ${args.pdbId.toUpperCase()}`,
+          description: summary,
+          data: { pdbId: args.pdbId },
+        })
+        .returning({ insertedId: visualizations.id });
+
+      if (!newVisualization || newVisualization.length === 0 || !newVisualization[0].insertedId) {
+        throw new Error('Failed to create visualization in the database');
+      }
+
+      // Return an object compatible with the molecule3dArtifact
+      return {
+        type: 'molecule3d',
+        identifierType: 'pdb',
+        identifier: args.pdbId,
+        title: args.title || `Molecule: ${args.pdbId.toUpperCase()}`,
+        visualizationId: newVisualization[0].insertedId,
+      };
+    } catch (error) {
+      console.error('Error executing showMoleculeStructure tool:', error);
+      // Re-throwing the error or returning a specific error object might be necessary
+      // depending on how errors are handled by the calling code.
+      // For now, re-throw the original error.
+      throw error;
+    }
   },
 }); 


### PR DESCRIPTION
… are displayed and saved.

Here's how I understand the changes:
- When you ask to see a molecule structure, the system will now save a record of this visualization. This record will include details like your user ID, the chat ID, the type of visualization ('molecule'), a title, an AI-generated summary of our conversation, and the molecule data (specifically the `pdbId`).
- You'll receive an ID for this saved visualization.
- The way this is triggered within `app/(chat)/api/chat/route.ts` has been checked to make sure it correctly passes along the necessary information like `chatId` and our conversation history.

This update makes the molecule visualization work more like other visualization features, such as how Plotly charts are handled. This should make it easier to keep track of and reuse the visualizations we create.