### PR TITLE
feat: Refactor artifact pipeline for new visualizations

### DIFF
--- a/app/(chat)/api/visualizations/[id]/route.ts
+++ b/app/(chat)/api/visualizations/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db'; // Assuming db instance is exported from here
+import { visualizations } from '@/lib/db/schema'; // Assuming schema is here
+import { eq } from 'drizzle-orm';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const visualizationId = params.id;
+
+    if (!visualizationId) {
+      return NextResponse.json({ error: 'Visualization ID is required' }, { status: 400 });
+    }
+
+    const visualization = await db.query.visualizations.findFirst({
+      where: eq(visualizations.id, visualizationId),
+    });
+
+    if (!visualization) {
+      return NextResponse.json({ error: 'Visualization not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(visualization);
+  } catch (error) {
+    console.error('Failed to fetch visualization:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/components/artifact.tsx
+++ b/components/artifact.tsx
@@ -26,6 +26,8 @@ import { codeArtifact } from '@/artifacts/code/client';
 import { sheetArtifact } from '@/artifacts/sheet/client';
 import { textArtifact } from '@/artifacts/text/client';
 import { molecule3dArtifact } from '@/artifacts/molecule3d/client';
+import PlotlyArtifact from '@/components/visualizations/plotly-artifact';
+import MoleculeArtifact from '@/components/visualizations/molecule-artifact';
 import equal from 'fast-deep-equal';
 import type { UseChatHelpers } from '@ai-sdk/react';
 import type { VisibilityType } from './visibility-selector';
@@ -453,25 +455,46 @@ function PureArtifact({
             </div>
 
             <div className="dark:bg-muted bg-background h-full overflow-y-scroll !max-w-full items-center">
-              <artifactDefinition.content
-                title={artifact.title}
-                content={
-                  isCurrentVersion
-                    ? artifact.content
-                    : getDocumentContentById(currentVersionIndex)
+              {(() => {
+                // Assuming artifact has `name` and `result` properties.
+                // The type `UIArtifact` might need to be updated if not already.
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const currentArtifact = artifact as any;
+
+                if (currentArtifact.name === 'createPlotlyChart' && currentArtifact.result?.visualizationId) {
+                  return <PlotlyArtifact visualizationId={currentArtifact.result.visualizationId} />;
+                } else if (currentArtifact.name === 'showMoleculeStructure' && currentArtifact.result?.visualizationId) {
+                  return <MoleculeArtifact visualizationId={currentArtifact.result.visualizationId} />;
+                } else {
+                  // Fallback to existing logic if artifactDefinition is available
+                  if (artifactDefinition) {
+                    return (
+                      <artifactDefinition.content
+                        title={artifact.title}
+                        content={
+                          isCurrentVersion
+                            ? artifact.content
+                            : getDocumentContentById(currentVersionIndex)
+                        }
+                        mode={mode}
+                        status={artifact.status}
+                        currentVersionIndex={currentVersionIndex}
+                        suggestions={[]}
+                        onSaveContent={saveContent}
+                        isInline={false}
+                        isCurrentVersion={isCurrentVersion}
+                        getDocumentContentById={getDocumentContentById}
+                        isLoading={isDocumentsFetching && !artifact.content}
+                        metadata={metadata}
+                        setMetadata={setMetadata}
+                      />
+                    );
+                  } else {
+                    // Handle cases where artifactDefinition might not be found
+                    return <div>Unsupported artifact type or missing definition.</div>;
+                  }
                 }
-                mode={mode}
-                status={artifact.status}
-                currentVersionIndex={currentVersionIndex}
-                suggestions={[]}
-                onSaveContent={saveContent}
-                isInline={false}
-                isCurrentVersion={isCurrentVersion}
-                getDocumentContentById={getDocumentContentById}
-                isLoading={isDocumentsFetching && !artifact.content}
-                metadata={metadata}
-                setMetadata={setMetadata}
-              />
+              })()}
 
               <AnimatePresence>
                 {isCurrentVersion && (

--- a/components/visualizations/molecule-artifact.tsx
+++ b/components/visualizations/molecule-artifact.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import useSWR from 'swr';
+import { Skeleton } from '@/components/ui/skeleton';
+import { MolstarViewer } from '@/components/visualizations/MolstarViewer';
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+interface VisualizationData {
+  id: string;
+  title: string;
+  description: string;
+  pdbId: string; // pdbId is expected by MolstarViewer
+  // Add any other fields that might come from the API and are needed
+}
+
+interface MoleculeArtifactProps {
+  visualizationId: string;
+}
+
+export default function MoleculeArtifact({ visualizationId }: MoleculeArtifactProps) {
+  const { data: visualization, error } = useSWR<VisualizationData>(
+    `/api/visualizations/${visualizationId}`,
+    fetcher
+  );
+
+  if (error) return <div>Failed to load visualization.</div>;
+  if (!visualization) return <Skeleton className="h-64 w-full" />; // Adjusted skeleton size
+
+  return (
+    <div className="p-4">
+      {visualization.title && (
+        <h2 className="text-lg font-semibold mb-2">{visualization.title}</h2>
+      )}
+      {visualization.description && (
+        <p className="text-sm text-muted-foreground mb-4">{visualization.description}</p>
+      )}
+      <MolstarViewer pdbId={visualization.pdbId} title={visualization.title} />
+    </div>
+  );
+}

--- a/components/visualizations/plotly-artifact.tsx
+++ b/components/visualizations/plotly-artifact.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import useSWR from 'swr';
+import { Skeleton } from '@/components/ui/skeleton';
+import { PlotlyChart, type FigureJSON } from '@/components/visualizations/PlotlyChart'; // Ensure PlotlyChartProps is exported or defined here
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+interface VisualizationData {
+  id: string;
+  title: string;
+  description: string;
+  data: FigureJSON; // This should match the structure expected by PlotlyChart
+  layout: any; // This should match the structure expected by PlotlyChart
+}
+
+interface PlotlyArtifactProps {
+  visualizationId: string;
+}
+
+export default function PlotlyArtifact({ visualizationId }: PlotlyArtifactProps) {
+  const { data: visualization, error } = useSWR<VisualizationData>(
+    `/api/visualizations/${visualizationId}`,
+    fetcher
+  );
+
+  if (error) return <div>Failed to load visualization.</div>;
+  if (!visualization) return <Skeleton className="h-64 w-full" />; // Adjusted skeleton size
+
+  return (
+    <div className="p-4">
+      {visualization.title && (
+        <h2 className="text-lg font-semibold mb-2">{visualization.title}</h2>
+      )}
+      {visualization.description && (
+        <p className="text-sm text-muted-foreground mb-4">{visualization.description}</p>
+      )}
+      <PlotlyChart figure={{data: visualization.data, layout: visualization.layout}} />
+    </div>
+  );
+}


### PR DESCRIPTION
This commit introduces support for rendering Plotly charts and molecule structures as first-class artifacts.

Key changes:

1.  **New Components:**
    *   `components/visualizations/plotly-artifact.tsx`: A client component that fetches visualization data by ID and renders a `PlotlyChart`. It includes loading skeletons and displays the title/description.
    *   `components/visualizations/molecule-artifact.tsx`: A client component that fetches visualization data by ID and renders a `MolstarViewer` for PDB structures. It also includes loading skeletons and displays title/description.

2.  **New API Endpoint:**
    *   `app/(chat)/api/visualizations/[id]/route.ts`: A GET endpoint to retrieve visualization data (including title, description, Plotly figure data, or PDB ID) from the database based on its ID.

3.  **Refactored `components/artifact.tsx`:**
    *   The main artifact rendering component now inspects the `artifact.name` and `artifact.result.visualizationId`.
    *   If `name` is `createPlotlyChart`, it renders `<PlotlyArtifact />`.
    *   If `name` is `showMoleculeStructure`, it renders `<MoleculeArtifact />`.
    *   Existing artifact rendering logic is preserved as a fallback for other types.

This refactoring allows for a more streamlined and specific way to handle complex visualization artifacts.