### PR TITLE
Fix: Correct syntax error in yield statement

### DIFF
--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -102,7 +102,7 @@ export async function continuePlaygroundConversation(
           data: z.object({}).passthrough().describe('The data for the chart, should be a valid Plotly data structure.'),
         }),
         render: async function* (props) {
-          yield <div>Generating plot: {props.title}...</div>;
+          yield (<div>Generating plot: {props.title}...</div>);
 
           try {
             if (visualizationId) {


### PR DESCRIPTION
The JSX expression in the render function was causing a syntax error. This commit fixes the error by wrapping the JSX expression in parentheses.