### PR TITLE
Fix: Correct JSX syntax in yield statement

### DIFF
--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -102,7 +102,7 @@ export async function continuePlaygroundConversation(
           data: z.object({}).passthrough().describe('The data for the chart, should be a valid Plotly data structure.'),
         }),
         render: async function* (props) {
-          yield (<div>Generating plot: {props.title}...</div>);
+          yield <div>Generating plot: {props.title}...</div>;
 
           try {
             if (visualizationId) {


### PR DESCRIPTION
The previous code had parentheses around JSX being yielded in a generator function, which caused a syntax error during the build process: "Tried to parse an argument of yield".

This commit removes the unnecessary parentheses to resolve the parsing error. The change is in `app/(chat)/actions.ts` within the `createPlotlyChart`'s `render` method.