### PR TITLE
Fix: Resolve TypeScript errors in CodeBlock component

### DIFF
--- a/components/code-block.tsx
+++ b/components/code-block.tsx
@@ -1,14 +1,14 @@
 'use client';
 
+import { type ReactNode } from 'react';
+
 interface CodeBlockProps {
-  node: any;
   inline: boolean;
   className: string;
-  children: any;
+  children: ReactNode;
 }
 
 export function CodeBlock({
-  node,
   inline,
   className,
   children,


### PR DESCRIPTION
- Typed `children` prop with `ReactNode` instead of `any`.
- Removed unused `node` prop from the component.